### PR TITLE
fix: crash when printing warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,9 +155,9 @@ async function restoreCache(cacheConfig) {
   await setTimeout(delay)
 
   core.startGroup(`Restore cache for ${cacheConfig.name}`)
+  const name = cacheConfig.name
   try {
     const hash = await glob.hashFiles(cacheConfig.files.join('\n'))
-    const name = cacheConfig.name
     const paths = cacheConfig.paths
     const restoreKey = `${config.baseCacheKey}-${name}-`
     const key = `${restoreKey}${hash}`


### PR DESCRIPTION
name needs to be in scope, otherwise the action will crash and the job using it fail

name is accessed at https://github.com/bazel-contrib/setup-bazel/blob/c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86/index.js#L182